### PR TITLE
fix(css): fix horizontal scrolling off code snippets on mobile devices (resolves #61)

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -63,7 +63,6 @@ pre code {
   overflow-wrap: break-word;
   overflow-x: auto;
   word-break: break-word;
-  white-space: pre-wrap;
 }
 
 code {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Remove an unneeded css property on class `pre code` to fix the scroll behaviour of code snippets on mobile devices

## Use Cases
<!-- An explanation of the use cases your change enables -->
Code snippets in blog posts, read on mobile devices, will now respect the lines breaks set by the author.
Readers will have properly formatted snippets on mobile devices with the ability to horizontally scroll in the snippets content.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

Here are screenshots with the fix run locally:
![paqueto-buildpack-blog-fixed-hoizontal-scroll-1:3](https://github.com/paketo-buildpacks/blog/assets/441686/a187823b-eee2-4324-a2d3-8dd347d03fbd)
![paqueto-buildpack-blog-fixed-hoizontal-scroll-2:3](https://github.com/paketo-buildpacks/blog/assets/441686/d02754d4-e4f6-4186-bbfd-365766ba27f3)
![paqueto-buildpack-blog-fixed-hoizontal-scroll-3:3](https://github.com/paketo-buildpacks/blog/assets/441686/991c2c09-8985-4057-94f2-abc62ca4bbd8)
